### PR TITLE
add new server interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/titan-data/s3web-remote-go
 
 require (
 	github.com/stretchr/testify v1.4.0
-	github.com/titan-data/remote-sdk-go v0.1.0
+	github.com/titan-data/remote-sdk-go v0.2.1
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.10.1 h1:uyt/l0dWjJ879yiAu+T7FG3/6QX+zwm4bQ8P7XsYt3o=
 github.com/hashicorp/go-hclog v0.10.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v0.11.0 h1:zf3QG3ap4KOMHzDLxBvq9ZtEFVSxQzVdH1ccl5NK2tU=
+github.com/hashicorp/go-hclog v0.11.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-plugin v1.0.1 h1:4OtAfUGbnKC6yS48p0CtMX2oFYtzFZVv6rok3cRWgnE=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
@@ -48,6 +50,8 @@ github.com/titan-data/remote-sdk-go v0.0.3 h1:kGLc7JP7znTcXyl3gRML2jEST99ebdhz0C
 github.com/titan-data/remote-sdk-go v0.0.3/go.mod h1:b4McaOFiLYWv2/wCQW/sE2BcCSNz/Ae6iKKEtqw703w=
 github.com/titan-data/remote-sdk-go v0.1.0 h1:Xab4sduqyGdo04eJ5mQ2lIfAYZDjHJ4AzlK4oJ5EqqE=
 github.com/titan-data/remote-sdk-go v0.1.0/go.mod h1:u7w3Olu3EtjoFcHzxUOzelxedey4q2nveuKLvgRO7tg=
+github.com/titan-data/remote-sdk-go v0.2.1 h1:Aa1CWqSbPIIvuacy27nMcbmLF2eymLIJs8m+yW8ki8E=
+github.com/titan-data/remote-sdk-go v0.2.1/go.mod h1:IYCrMWL1hFGoYusrTHgseG/bLVuY72LpQSSdGOrcHb4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/s3web/s3web.go
+++ b/s3web/s3web.go
@@ -20,20 +20,20 @@ func (s s3webRemote) Type() (string, error) {
 }
 
 func (s s3webRemote) FromURL(rawUrl string, additionalProperties map[string]string) (map[string]interface{}, error) {
-	url, err := url.Parse(rawUrl)
+	u, err := url.Parse(rawUrl)
 	if err != nil {
 		return nil, err
 	}
 
-	if url.Scheme != "s3web" {
+	if u.Scheme != "s3web" {
 		return nil, errors.New("invalid remote scheme")
 	}
 
-	if url.User != nil {
+	if u.User != nil {
 		return nil, errors.New("remote username and password cannot be specified")
 	}
 
-	if url.Hostname() == "" {
+	if u.Hostname() == "" {
 		return nil, errors.New("missing remote host name")
 	}
 
@@ -41,8 +41,8 @@ func (s s3webRemote) FromURL(rawUrl string, additionalProperties map[string]stri
 		return nil, errors.New(fmt.Sprintf("invalid property '%s'", reflect.ValueOf(additionalProperties).MapKeys()[0].String()))
 	}
 
-	u := fmt.Sprintf("http://%s%s", url.Host, url.Path)
-	return map[string]interface{}{"url": u}, nil
+	res := fmt.Sprintf("http://%s%s", u.Host, u.Path)
+	return map[string]interface{}{"url": res}, nil
 }
 
 func (s s3webRemote) ToURL(properties map[string]interface{}) (string, map[string]string, error) {
@@ -52,6 +52,22 @@ func (s s3webRemote) ToURL(properties map[string]interface{}) (string, map[strin
 
 func (s s3webRemote) GetParameters(remoteProperties map[string]interface{}) (map[string]interface{}, error) {
 	return map[string]interface{}{}, nil
+}
+
+func (s s3webRemote) ValidateRemote(properties map[string]interface{}) error {
+	panic("implement me")
+}
+
+func (s s3webRemote) ValidateParameters(parameters map[string]interface{}) error {
+	panic("implement me")
+}
+
+func (s s3webRemote) ListCommits(properties map[string]interface{}, parameters map[string]interface{}, tags []remote.Tag) ([]remote.Commit, error) {
+	panic("implement me")
+}
+
+func (s s3webRemote) GetCommit(properties map[string]interface{}, parameters map[string]interface{}, commitId string) (*remote.Commit, error) {
+	panic("implement me")
 }
 
 func init() {

--- a/s3web/s3web.go
+++ b/s3web/s3web.go
@@ -4,9 +4,13 @@
 package s3web
 
 import (
+	"bufio"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/titan-data/remote-sdk-go/remote"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
@@ -55,19 +59,68 @@ func (s s3webRemote) GetParameters(remoteProperties map[string]interface{}) (map
 }
 
 func (s s3webRemote) ValidateRemote(properties map[string]interface{}) error {
-	panic("implement me")
+	return remote.ValidateFields(properties, []string{"url"}, []string{})
 }
 
 func (s s3webRemote) ValidateParameters(parameters map[string]interface{}) error {
-	panic("implement me")
+	return remote.ValidateFields(parameters, []string{}, []string{})
+}
+
+var httpGet = http.Get
+
+type MetadataCommit struct {
+	Id         string                 `json:"id"`
+	Properties map[string]interface{} `json:"properties"`
 }
 
 func (s s3webRemote) ListCommits(properties map[string]interface{}, parameters map[string]interface{}, tags []remote.Tag) ([]remote.Commit, error) {
-	panic("implement me")
+	metadataPath := fmt.Sprintf("%s/%s", properties["url"], "titan")
+	resp, err := httpGet(metadataPath)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return []remote.Commit{}, nil
+	}
+
+	if resp.StatusCode >= 300 {
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to get '%s': %s", metadataPath, string(b))
+	}
+
+	var ret []remote.Commit
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if (line) != "" {
+			commit := MetadataCommit{}
+			err = json.Unmarshal([]byte(line), &commit)
+			if err == nil && commit.Properties != nil && commit.Id != "" && remote.MatchTags(commit.Properties, tags) {
+				ret = append(ret, remote.Commit{Id: commit.Id, Properties: commit.Properties})
+			}
+		}
+	}
+
+	remote.SortCommits(ret)
+
+	return ret, nil
 }
 
 func (s s3webRemote) GetCommit(properties map[string]interface{}, parameters map[string]interface{}, commitId string) (*remote.Commit, error) {
-	panic("implement me")
+	commits, err := s.ListCommits(properties, parameters, []remote.Tag{})
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range commits {
+		if c.Id == commitId {
+			return &c, nil
+		}
+	}
+
+	return nil, nil
 }
 
 func init() {

--- a/s3web/s3web_test.go
+++ b/s3web/s3web_test.go
@@ -4,8 +4,12 @@
 package s3web
 
 import (
+	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/titan-data/remote-sdk-go/remote"
+	"io/ioutil"
+	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -36,6 +40,12 @@ func TestNoPath(t *testing.T) {
 func TestBadProperty(t *testing.T) {
 	r := remote.Get("s3web")
 	_, err := r.FromURL("s3web://host", map[string]string{"a": "b"})
+	assert.Error(t, err)
+}
+
+func TestBadUrl(t *testing.T) {
+	r := remote.Get("s3web")
+	_, err := r.FromURL("s3web://not\nhost", map[string]string{})
 	assert.Error(t, err)
 }
 
@@ -92,4 +102,200 @@ func TestParameters(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Empty(t, props)
 	}
+}
+
+func TestValidateRemoteRequired(t *testing.T) {
+	r := remote.Get("s3web")
+	err := r.ValidateRemote(map[string]interface{}{"url": "url"})
+	assert.NoError(t, err)
+}
+
+func TestValidateRemoteMissingRequired(t *testing.T) {
+	r := remote.Get("s3web")
+	err := r.ValidateRemote(map[string]interface{}{})
+	assert.Error(t, err)
+}
+
+func TestValidateRemoteInvalid(t *testing.T) {
+	r := remote.Get("s3web")
+	err := r.ValidateRemote(map[string]interface{}{"url": "url", "foo": "bar"})
+	assert.Error(t, err)
+}
+
+func TestValidateParametersEmpty(t *testing.T) {
+	r := remote.Get("s3web")
+	err := r.ValidateParameters(map[string]interface{}{})
+	assert.NoError(t, err)
+}
+
+func TestValidateParametersInvalid(t *testing.T) {
+	r := remote.Get("s3web")
+	err := r.ValidateParameters(map[string]interface{}{"foo": "bar"})
+	assert.Error(t, err)
+}
+
+func TestListCommitsBadGet(t *testing.T) {
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return nil, errors.New("error")
+	}
+	r := remote.Get("s3web")
+	_, err := r.ListCommits(map[string]interface{}{"url": "http://host/path"}, map[string]interface{}{},
+		[]remote.Tag{})
+	assert.Error(t, err)
+	httpGet = http.Get
+}
+
+func TestListCommitsNotFound(t *testing.T) {
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{StatusCode: http.StatusNotFound}, nil
+	}
+	r := remote.Get("s3web")
+	commits, err := r.ListCommits(map[string]interface{}{"url": "http://host/path"}, map[string]interface{}{},
+		[]remote.Tag{})
+	if assert.NoError(t, err) {
+		assert.Len(t, commits, 0)
+	}
+	httpGet = http.Get
+}
+
+func TestListCommitsOtherError(t *testing.T) {
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(strings.NewReader("bad request")),
+		}, nil
+	}
+	r := remote.Get("s3web")
+	_, err := r.ListCommits(map[string]interface{}{"url": "http://host/path"}, map[string]interface{}{},
+		[]remote.Tag{})
+	assert.Error(t, err)
+	httpGet = http.Get
+}
+
+type errReader int
+
+func (errReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("test error")
+}
+
+func TestListCommitsErrorReadError(t *testing.T) {
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(errReader(0)),
+		}, nil
+	}
+	r := remote.Get("s3web")
+	_, err := r.ListCommits(map[string]interface{}{"url": "http://host/path"}, map[string]interface{}{},
+		[]remote.Tag{})
+	assert.Error(t, err)
+	httpGet = http.Get
+}
+
+func TestListCommits(t *testing.T) {
+	metadata := `
+{"id": "one", "properties": {"timestamp": "2019-09-20T13:45:36Z"}}
+{"id": "two", "properties": {"timestamp": "2019-09-20T13:45:37Z"}}`
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader(metadata)),
+		}, nil
+	}
+	r := remote.Get("s3web")
+	commits, err := r.ListCommits(map[string]interface{}{"bucket": "bucket", "path": "path"}, map[string]interface{}{}, []remote.Tag{})
+	if assert.NoError(t, err) {
+		assert.Len(t, commits, 2)
+		assert.Equal(t, "two", commits[0].Id)
+		assert.Equal(t, "one", commits[1].Id)
+	}
+	httpGet = http.Get
+}
+
+func TestListCommitsInvalid(t *testing.T) {
+	metadata := `
+foo
+{"id": "two", "properties": {"timestamp": "2019-09-20T13:45:37Z"}}`
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader(metadata)),
+		}, nil
+	}
+	r := remote.Get("s3web")
+	commits, err := r.ListCommits(map[string]interface{}{"bucket": "bucket", "path": "path"}, map[string]interface{}{}, []remote.Tag{})
+	if assert.NoError(t, err) {
+		assert.Len(t, commits, 1)
+		assert.Equal(t, "two", commits[0].Id)
+	}
+	httpGet = http.Get
+}
+
+func TestListCommitsTags(t *testing.T) {
+	metadata := `
+{"id": "one", "properties": {"timestamp": "2019-09-20T13:45:36Z", "tags": { "a": "b" }}}
+{"id": "two", "properties": {"timestamp": "2019-09-20T13:45:37Z", "tags": { "c": "d" }}}`
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader(metadata)),
+		}, nil
+	}
+	r := remote.Get("s3web")
+	commits, err := r.ListCommits(map[string]interface{}{"bucket": "bucket", "path": "path"}, map[string]interface{}{}, []remote.Tag{{Key: "a"}})
+	if assert.NoError(t, err) {
+		assert.Len(t, commits, 1)
+		assert.Equal(t, "one", commits[0].Id)
+	}
+	httpGet = http.Get
+}
+
+func TestGetCommitError(t *testing.T) {
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(strings.NewReader("bad request")),
+		}, nil
+	}
+	r := remote.Get("s3web")
+	_, err := r.GetCommit(map[string]interface{}{"url": "http://host/path"}, map[string]interface{}{}, "id")
+	assert.Error(t, err)
+	httpGet = http.Get
+}
+
+func TestGetCommit(t *testing.T) {
+	metadata := `
+{"id": "one", "properties": {"timestamp": "2019-09-20T13:45:36Z"}}
+{"id": "two", "properties": {"timestamp": "2019-09-20T13:45:37Z"}}`
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader(metadata)),
+		}, nil
+	}
+	r := remote.Get("s3web")
+	commit, err := r.GetCommit(map[string]interface{}{"bucket": "bucket", "path": "path"}, map[string]interface{}{}, "one")
+	if assert.NoError(t, err) {
+		assert.Equal(t, "one", commit.Id)
+		assert.Equal(t, "2019-09-20T13:45:36Z", commit.Properties["timestamp"])
+	}
+	httpGet = http.Get
+}
+
+func TestGetMissingCommit(t *testing.T) {
+	metadata := `
+{"id": "one", "properties": {"timestamp": "2019-09-20T13:45:36Z"}}
+{"id": "two", "properties": {"timestamp": "2019-09-20T13:45:37Z"}}`
+	httpGet = func(url string) (resp *http.Response, err error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader(metadata)),
+		}, nil
+	}
+	r := remote.Get("s3web")
+	commit, err := r.GetCommit(map[string]interface{}{"bucket": "bucket", "path": "path"}, map[string]interface{}{}, "three")
+	if assert.NoError(t, err) {
+		assert.Nil(t, commit)
+	}
+	httpGet = http.Get
 }

--- a/s3web/s3web_test.go
+++ b/s3web/s3web_test.go
@@ -11,73 +11,85 @@ import (
 
 func TestRegistered(t *testing.T) {
 	r := remote.Get("s3web")
-	ret, _ := r.Type()
-	assert.Equal(t, "s3web", ret)
+	ret, err := r.Type()
+	if assert.NoError(t, err) {
+		assert.Equal(t, "s3web", ret)
+	}
 }
 
 func TestFromURL(t *testing.T) {
 	r := remote.Get("s3web")
-	props, _ := r.FromURL("s3web://host/object/path", map[string]string{})
-	assert.Equal(t, "http://host/object/path", props["url"])
+	props, err := r.FromURL("s3web://host/object/path", map[string]string{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "http://host/object/path", props["url"])
+	}
 }
 
 func TestNoPath(t *testing.T) {
 	r := remote.Get("s3web")
-	props, _ := r.FromURL("s3web://host", map[string]string{})
-	assert.Equal(t, "http://host", props["url"])
+	props, err := r.FromURL("s3web://host", map[string]string{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "http://host", props["url"])
+	}
 }
 
 func TestBadProperty(t *testing.T) {
 	r := remote.Get("s3web")
 	_, err := r.FromURL("s3web://host", map[string]string{"a": "b"})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadScheme(t *testing.T) {
 	r := remote.Get("s3web")
 	_, err := r.FromURL("s3web", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadSchemeName(t *testing.T) {
 	r := remote.Get("s3web")
 	_, err := r.FromURL("foo://bar", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadUser(t *testing.T) {
 	r := remote.Get("s3web")
 	_, err := r.FromURL("s3web://user@host/path", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadUserPassword(t *testing.T) {
 	r := remote.Get("s3web")
 	_, err := r.FromURL("s3web://user:password@host/path", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBadNoHost(t *testing.T) {
 	r := remote.Get("s3web")
 	_, err := r.FromURL("s3web:///path", map[string]string{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestPort(t *testing.T) {
 	r := remote.Get("s3web")
-	props, _ := r.FromURL("s3web://host:1023/object/path", map[string]string{})
-	assert.Equal(t, "http://host:1023/object/path", props["url"])
+	props, err := r.FromURL("s3web://host:1023/object/path", map[string]string{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "http://host:1023/object/path", props["url"])
+	}
 }
 
 func TestToURL(t *testing.T) {
 	r := remote.Get("s3web")
-	u, props, _ := r.ToURL(map[string]interface{}{"url": "http://host/path"})
-	assert.Equal(t, "s3web://host/path", u)
-	assert.Empty(t, props)
+	u, props, err := r.ToURL(map[string]interface{}{"url": "http://host/path"})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "s3web://host/path", u)
+		assert.Empty(t, props)
+	}
 }
 
 func TestParameters(t *testing.T) {
 	r := remote.Get("s3web")
-	props, _ := r.GetParameters(map[string]interface{}{"url": "http://host/path"})
-	assert.Empty(t, props)
+	props, err := r.GetParameters(map[string]interface{}{"url": "http://host/path"})
+	if assert.NoError(t, err) {
+		assert.Empty(t, props)
+	}
 }


### PR DESCRIPTION
## Proposed Changes

This updates `s3web` to `remote-sdk-go` 0.2.1 and adds the relevant server-side interfaces.

## Testing

`go test ./...` and verified 100% statement coverage.